### PR TITLE
Added functionality to inject custom headers in requestor and create …

### DIFF
--- a/order/client.go
+++ b/order/client.go
@@ -5,9 +5,9 @@ import (
 )
 
 // Create creates a new order
-func Create(p *conekta.OrderParams) (*conekta.Order, *conekta.Error) {
+func Create(p *conekta.OrderParams, customHeaders ...interface{}) (*conekta.Order, *conekta.Error) {
 	ord := &conekta.Order{}
-	err := conekta.MakeRequest("POST", "/orders", p, ord)
+	err := conekta.MakeRequest("POST", "/orders", p, ord, customHeaders...)
 	return ord, err
 }
 

--- a/token/client.go
+++ b/token/client.go
@@ -1,6 +1,8 @@
 package token
 
 import (
+	"encoding/base64"
+
 	conekta "github.com/conekta/conekta-go"
 )
 
@@ -8,6 +10,12 @@ import (
 // For details see https://developers.conekta.com/api#create-discount-line
 func Create(p *conekta.TokenParams) (*conekta.Token, *conekta.Error) {
 	tk := &conekta.Token{}
-	err := conekta.MakeRequest("POST", "/tokens", p, tk)
+	h := map[string]string{
+		"Authorization":             "Basic " + base64.StdEncoding.EncodeToString([]byte(conekta.PubliAPIKey)),
+		"Conekta-Client-User-Agent": "{\"agent\":\"Conekta JavascriptBindings/0.3.0\"}",
+		"RaiseHtmlError":            "false",
+		"Accept":                    "application/vnd.conekta-v0.3.0+json",
+	}
+	err := conekta.MakeRequest("POST", "/tokens", p, tk, h)
 	return tk, err
 }


### PR DESCRIPTION
**Why is this change necessary?**
We need to inject custom headers in customer create

**How does it address the issue?**
By adding a dynamic interface that receives a map[string]string   to inject headers

**What side effects does this change have?**
nothing

