### PR TITLE
Refactor error handling

### DIFF
--- a/charge/charge_test.go
+++ b/charge/charge_test.go
@@ -13,12 +13,12 @@ func init() {
 	conekta.APIKey = conekta.TestKey
 }
 
-func CreateOrder() (*conekta.Order, *conekta.Error) {
+func CreateOrder() (*conekta.Order, error) {
 	op := &conekta.OrderParams{}
 	ord, err := order.Create(op.Mock())
 	return ord, err
 }
-func CreateOrderWithoutCharges() (*conekta.Order, *conekta.Error) {
+func CreateOrderWithoutCharges() (*conekta.Order, error) {
 	op := &conekta.OrderParams{}
 	ord, err := order.Create(op.MockWithoutCharges())
 	return ord, err
@@ -46,7 +46,7 @@ func TestCreateError(t *testing.T) {
 	ord, _ := CreateOrderWithoutCharges()
 	_, err := Create(ord.ID, &conekta.ChargeParams{})
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "parameter_validation_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "parameter_validation_error")
 }
 
 func TestFind(t *testing.T) {
@@ -69,5 +69,5 @@ func TestFindError(t *testing.T) {
 	ord, _ := CreateOrderWithoutCharges()
 	_, err := Find(ord.ID, "123")
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "resource_not_found_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "resource_not_found_error")
 }

--- a/charge/client.go
+++ b/charge/client.go
@@ -6,14 +6,14 @@ import (
 
 //Create charges object sending requesto api
 //For more information please see https://developers.conekta.com/api#create-charge
-func Create(orderID string, p *conekta.ChargeParams) (*conekta.Charge, *conekta.Error) {
+func Create(orderID string, p *conekta.ChargeParams) (*conekta.Charge, error) {
 	ch := &conekta.Charge{}
 	err := conekta.MakeRequest("POST", "/orders/"+orderID+"/charges", p, ch)
 	return ch, err
 }
 
 //Find returns a charge based on his unique ID
-func Find(orderID string, id string) (*conekta.Charge, *conekta.Error) {
+func Find(orderID string, id string) (*conekta.Charge, error) {
 	ch := &conekta.Charge{}
 	err := conekta.MakeRequest("GET", "/orders/"+orderID+"/charges/"+id, &conekta.EmptyParams{}, ch)
 	return ch, err

--- a/customer/client.go
+++ b/customer/client.go
@@ -6,7 +6,7 @@ import (
 
 // Create creates a new customer
 // For details see https://developers.conekta.com/api#create-customer
-func Create(p *conekta.CustomerParams) (*conekta.Customer, *conekta.Error) {
+func Create(p *conekta.CustomerParams) (*conekta.Customer, error) {
 	cust := &conekta.Customer{}
 	err := conekta.MakeRequest("POST", "/customers", p, cust)
 	return cust, err
@@ -14,28 +14,28 @@ func Create(p *conekta.CustomerParams) (*conekta.Customer, *conekta.Error) {
 
 // Update updates a customer
 // For details see https://developers.conekta.com/api#update-customer
-func Update(id string, p *conekta.CustomerParams) (*conekta.Customer, *conekta.Error) {
+func Update(id string, p *conekta.CustomerParams) (*conekta.Customer, error) {
 	cust := &conekta.Customer{}
 	err := conekta.MakeRequest("PUT", "/customers/"+id, p, cust)
 	return cust, err
 }
 
 // Find gets a customer by id
-func Find(id string) (*conekta.Customer, *conekta.Error) {
+func Find(id string) (*conekta.Customer, error) {
 	cust := &conekta.Customer{}
 	err := conekta.MakeRequest("GET", "/customers/"+id, &conekta.EmptyParams{}, cust)
 	return cust, err
 }
 
 // Delete deletes a customer
-func Delete(id string) (*conekta.Customer, *conekta.Error) {
+func Delete(id string) (*conekta.Customer, error) {
 	cust := &conekta.Customer{}
 	err := conekta.MakeRequest("DELETE", "/customers/"+id, &conekta.EmptyParams{}, cust)
 	return cust, err
 }
 
 // All gets all customers
-func All() (*conekta.CustomerList, *conekta.Error) {
+func All() (*conekta.CustomerList, error) {
 	cl := &conekta.CustomerList{}
 	err := conekta.MakeRequest("GET", "/customers", &conekta.EmptyParams{}, cl)
 	return cl, err

--- a/customer/customer_test.go
+++ b/customer/customer_test.go
@@ -26,7 +26,7 @@ func TestCreate(t *testing.T) {
 func TestCreateError(t *testing.T) {
 	_, err := Create(&conekta.CustomerParams{})
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "parameter_validation_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "parameter_validation_error")
 }
 
 func TestUpdate(t *testing.T) {
@@ -46,7 +46,7 @@ func TestUpdateError(t *testing.T) {
 	cp.Email = email
 	_, err := Update(cust.ID, cp)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "parameter_validation_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "parameter_validation_error")
 }
 
 func TestFind(t *testing.T) {
@@ -61,7 +61,7 @@ func TestFind(t *testing.T) {
 func TestFindError(t *testing.T) {
 	_, err := Find("122")
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "resource_not_found_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "resource_not_found_error")
 }
 
 func TestDelete(t *testing.T) {
@@ -75,7 +75,7 @@ func TestDelete(t *testing.T) {
 func TestDeleteError(t *testing.T) {
 	_, err := Delete("122")
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "resource_not_found_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "resource_not_found_error")
 }
 
 func TestAll(t *testing.T) {

--- a/discountlines/client.go
+++ b/discountlines/client.go
@@ -4,7 +4,7 @@ import conekta "github.com/conekta/conekta-go"
 
 //Create create discount line insde a order
 // For details see https://developers.conekta.com/api#create-discount-line
-func Create(orderID string, p *conekta.DiscountLinesParams) (*conekta.DiscountLines, *conekta.Error) {
+func Create(orderID string, p *conekta.DiscountLinesParams) (*conekta.DiscountLines, error) {
 	dlp := &conekta.DiscountLines{}
 	err := conekta.MakeRequest("POST", "/orders/"+orderID+"/discount_lines", p, dlp)
 	return dlp, err
@@ -12,14 +12,14 @@ func Create(orderID string, p *conekta.DiscountLinesParams) (*conekta.DiscountLi
 
 // Update updates a DiscountLine inside order
 // For details see https://developers.conekta.com/api#update-discount-line
-func Update(orderID string, id string, p *conekta.DiscountLinesParams) (*conekta.DiscountLines, *conekta.Error) {
+func Update(orderID string, id string, p *conekta.DiscountLinesParams) (*conekta.DiscountLines, error) {
 	ord := &conekta.DiscountLines{}
 	err := conekta.MakeRequest("PUT", "/orders/"+orderID+"/discount_lines/"+id, p, ord)
 	return ord, err
 }
 
 // Delete deletes a Order Discount Line
-func Delete(orderID string, id string) (*conekta.DiscountLines, *conekta.Error) {
+func Delete(orderID string, id string) (*conekta.DiscountLines, error) {
 	ord := &conekta.DiscountLines{}
 	err := conekta.MakeRequest("DELETE", "/orders/"+orderID+"/discount_lines/"+id, &conekta.OrderParams{}, ord)
 	return ord, err

--- a/discountlines/discountlines_test.go
+++ b/discountlines/discountlines_test.go
@@ -13,12 +13,12 @@ func init() {
 	conekta.APIKey = conekta.TestKey
 }
 
-func CreateOrderWithoutCharges() (*conekta.Order, *conekta.Error) {
+func CreateOrderWithoutCharges() (*conekta.Order, error) {
 	op := &conekta.OrderParams{}
 	ord, err := order.Create(op.MockWithoutCharges())
 	return ord, err
 }
-func CreateOrderWithoutDiscountLines() (*conekta.Order, *conekta.Error) {
+func CreateOrderWithoutDiscountLines() (*conekta.Order, error) {
 	op := &conekta.OrderParams{}
 	ord, err := order.Create(op.MockWithoutDiscountLines())
 	return ord, err
@@ -44,7 +44,7 @@ func TestCreateError(t *testing.T) {
 	_, err := Create(ord.ID, &conekta.DiscountLinesParams{})
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "parameter_validation_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "parameter_validation_error")
 }
 
 func TestDelete(t *testing.T) {
@@ -57,7 +57,7 @@ func TestDeleteError(t *testing.T) {
 	ord, _ := CreateOrderWithoutCharges()
 	_, err := Delete(ord.ID, "123")
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "resource_not_found_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "resource_not_found_error")
 }
 
 func TestUpdate(t *testing.T) {
@@ -77,5 +77,5 @@ func TestUpdateError(t *testing.T) {
 	dlp.Amount = -1
 	_, err := Update(ord.ID, ord.DiscountLines.Data[0].ID, dlp)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "parameter_validation_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "parameter_validation_error")
 }

--- a/error.go
+++ b/error.go
@@ -2,6 +2,7 @@ package conekta
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // ErrorDetails gives especific information about an error
@@ -19,8 +20,8 @@ type Error struct {
 	Details   []ErrorDetails `json:"details,omitempty"`
 }
 
-func getConectionError() *Error {
-	return &Error{
+func getConectionError() Error {
+	return Error{
 		ErrorType: "error.requestor.connection_purchaser",
 		Details: []ErrorDetails{
 			{
@@ -30,8 +31,12 @@ func getConectionError() *Error {
 	}
 }
 
-func getAPIError(b []byte) *Error {
+func getAPIError(b []byte) Error {
 	e := Error{}
 	json.Unmarshal(b, &e)
-	return &e
+	return e
+}
+
+func (e Error) Error() string {
+	return fmt.Sprintf("%v: %v", e.ErrorType, e.Details)
 }

--- a/lineitems/client.go
+++ b/lineitems/client.go
@@ -6,7 +6,7 @@ import (
 
 //Create function creates a line_item object
 //For more information please see https://developers.conekta.com/api#create-line-item
-func Create(id string, p *conekta.LineItemsParams) (*conekta.LineItems, *conekta.Error) {
+func Create(id string, p *conekta.LineItemsParams) (*conekta.LineItems, error) {
 	li := &conekta.LineItems{}
 	err := conekta.MakeRequest("POST", "/orders/"+id+"/line_items", p, li)
 	return li, err
@@ -14,14 +14,14 @@ func Create(id string, p *conekta.LineItemsParams) (*conekta.LineItems, *conekta
 
 // Update updates a Order
 // For details see https://developers.conekta.com/api#update-Order
-func Update(orderID string, id string, p *conekta.LineItemsParams) (*conekta.LineItems, *conekta.Error) {
+func Update(orderID string, id string, p *conekta.LineItemsParams) (*conekta.LineItems, error) {
 	li := &conekta.LineItems{}
 	err := conekta.MakeRequest("PUT", "/orders/"+orderID+"/line_items/"+id, p, li)
 	return li, err
 }
 
 // Delete deletes a Order
-func Delete(orderID string, id string) (*conekta.LineItems, *conekta.Error) {
+func Delete(orderID string, id string) (*conekta.LineItems, error) {
 	li := &conekta.LineItems{}
 	err := conekta.MakeRequest("DELETE", "/orders/"+orderID+"/line_items/"+id, &conekta.LineItemsParams{}, li)
 	return li, err

--- a/lineitems/lineitems_test.go
+++ b/lineitems/lineitems_test.go
@@ -13,7 +13,7 @@ func init() {
 	conekta.APIKey = conekta.TestKey
 }
 
-func CreateOrderWithoutCharges() (*conekta.Order, *conekta.Error) {
+func CreateOrderWithoutCharges() (*conekta.Order, error) {
 	op := &conekta.OrderParams{}
 	ord, err := order.Create(op.MockWithoutCharges())
 	return ord, err
@@ -34,7 +34,7 @@ func TestCreateError(t *testing.T) {
 	ord, _ := CreateOrderWithoutCharges()
 	_, err := Create(ord.ID, &conekta.LineItemsParams{})
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "parameter_validation_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "parameter_validation_error")
 }
 
 func TestUpdate(t *testing.T) {
@@ -54,7 +54,7 @@ func TestUpdateError(t *testing.T) {
 	lip.Quantity = -1
 	_, err := Update(ord.ID, li.ID, lip)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "parameter_validation_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "parameter_validation_error")
 }
 
 func TestDelete(t *testing.T) {
@@ -71,5 +71,5 @@ func TestDeleteError(t *testing.T) {
 	ord, _ := CreateOrderWithoutCharges()
 	_, err := Delete(ord.ID, "123")
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "resource_not_found_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "resource_not_found_error")
 }

--- a/order/client.go
+++ b/order/client.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Create creates a new order
-func Create(p *conekta.OrderParams, customHeaders ...interface{}) (*conekta.Order, *conekta.Error) {
+func Create(p *conekta.OrderParams, customHeaders ...interface{}) (*conekta.Order, error) {
 	ord := &conekta.Order{}
 	err := conekta.MakeRequest("POST", "/orders", p, ord, customHeaders...)
 	return ord, err
@@ -13,21 +13,21 @@ func Create(p *conekta.OrderParams, customHeaders ...interface{}) (*conekta.Orde
 
 // Update updates a Order
 // For details see https://developers.conekta.com/api#update-Order
-func Update(id string, p *conekta.OrderParams) (*conekta.Order, *conekta.Error) {
+func Update(id string, p *conekta.OrderParams) (*conekta.Order, error) {
 	ord := &conekta.Order{}
 	err := conekta.MakeRequest("PUT", "/orders/"+id, p, ord)
 	return ord, err
 }
 
 // Capture deletes a Order
-func Capture(id string) (*conekta.Order, *conekta.Error) {
+func Capture(id string) (*conekta.Order, error) {
 	ord := &conekta.Order{}
 	err := conekta.MakeRequest("POST", "/orders/"+id+"/capture", &conekta.OrderParams{}, ord)
 	return ord, err
 }
 
 // Find gets a order by id
-func Find(id string) (*conekta.Order, *conekta.Error) {
+func Find(id string) (*conekta.Order, error) {
 	ord := &conekta.Order{}
 	err := conekta.MakeRequest("GET", "/orders/"+id, &conekta.OrderParams{}, ord)
 	return ord, err

--- a/order/order_test.go
+++ b/order/order_test.go
@@ -171,8 +171,7 @@ func TestCapture(t *testing.T) {
 	res, err := Capture(ord.ID)
 	assert.Equal(t, false, res.PreAuth)
 	assert.Equal(t, "paid", res.PaymentStatus)
-	assert.NotEqual(t, nil, err)
-
+	assert.Nil(t, err)
 }
 
 func TestFind(t *testing.T) {
@@ -180,5 +179,5 @@ func TestFind(t *testing.T) {
 	ord, _ := Create(op.Mock())
 	res, err := Find(ord.ID)
 	assert.Equal(t, ord.ID, res.ID)
-	assert.NotEqual(t, nil, err)
+	assert.Nil(t, err)
 }

--- a/paymentsource/client.go
+++ b/paymentsource/client.go
@@ -6,7 +6,7 @@ import (
 
 // Create creates a new payment source
 // For details see https://developers.conekta.com/api#payment-source.
-func Create(custID string, p *conekta.PaymentSourceCreateParams) (*conekta.PaymentSource, *conekta.Error) {
+func Create(custID string, p *conekta.PaymentSourceCreateParams) (*conekta.PaymentSource, error) {
 	ps := &conekta.PaymentSource{}
 	err := conekta.MakeRequest("POST", "/customers/"+custID+"/payment_sources", p, ps)
 	return ps, err
@@ -14,7 +14,7 @@ func Create(custID string, p *conekta.PaymentSourceCreateParams) (*conekta.Payme
 
 // Update updates a payment source
 // For details see https://developers.conekta.com/api#update-shipping-contact
-func Update(custID string, id string, p *conekta.PaymentSourceUpdateParams) (*conekta.PaymentSource, *conekta.Error) {
+func Update(custID string, id string, p *conekta.PaymentSourceUpdateParams) (*conekta.PaymentSource, error) {
 	ps := &conekta.PaymentSource{}
 	err := conekta.MakeRequest("PUT", "/customers/"+custID+"/payment_sources/"+id, p, ps)
 	return ps, err
@@ -22,21 +22,21 @@ func Update(custID string, id string, p *conekta.PaymentSourceUpdateParams) (*co
 
 // Delete deletes a payment source
 // For details see https://developers.conekta.com/api#delete-payment-source.
-func Delete(custID string, id string) (*conekta.PaymentSource, *conekta.Error) {
+func Delete(custID string, id string) (*conekta.PaymentSource, error) {
 	ps := &conekta.PaymentSource{}
 	err := conekta.MakeRequest("DELETE", "/customers/"+custID+"/payment_sources/"+id, &conekta.EmptyParams{}, ps)
 	return ps, err
 }
 
 // Find gets a payment source
-func Find(custID string, id string) (*conekta.PaymentSource, *conekta.Error) {
+func Find(custID string, id string) (*conekta.PaymentSource, error) {
 	ps := &conekta.PaymentSource{}
 	err := conekta.MakeRequest("GET", "/customers/"+custID+"/payment_sources/"+id, &conekta.EmptyParams{}, ps)
 	return ps, err
 }
 
 // All gets all payment sources from a customer
-func All(custID string) (*conekta.PaymentSourceList, *conekta.Error) {
+func All(custID string) (*conekta.PaymentSourceList, error) {
 	ps := &conekta.PaymentSourceList{}
 	err := conekta.MakeRequest("GET", "/customers/"+custID+"/payment_sources/", &conekta.EmptyParams{}, ps)
 	return ps, err

--- a/paymentsource/paymentsource_test.go
+++ b/paymentsource/paymentsource_test.go
@@ -19,7 +19,7 @@ func createCustomer() *conekta.Customer {
 	return cust
 }
 
-func createPaymentSource() (*conekta.PaymentSource, *conekta.Customer, *conekta.Error) {
+func createPaymentSource() (*conekta.PaymentSource, *conekta.Customer, error) {
 	cust := createCustomer()
 	psp := &conekta.PaymentSourceCreateParams{}
 	ps, err := Create(cust.ID, psp.Mock())
@@ -38,7 +38,7 @@ func TestCreateError(t *testing.T) {
 	cust := createCustomer()
 	_, err := Create(cust.ID, &conekta.PaymentSourceCreateParams{})
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "parameter_validation_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "parameter_validation_error")
 }
 
 func TestUpdate(t *testing.T) {
@@ -57,7 +57,7 @@ func TestUpdateError(t *testing.T) {
 	psp.ExpYear = "1"
 	_, err := Update(cust.ID, ps.ID, psp)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "parameter_validation_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "parameter_validation_error")
 }
 
 func TestFind(t *testing.T) {
@@ -71,7 +71,7 @@ func TestFindError(t *testing.T) {
 	c := createCustomer()
 	_, err := Find(c.ID, "123")
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "resource_not_found_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "resource_not_found_error")
 }
 
 func TestDelete(t *testing.T) {
@@ -85,7 +85,7 @@ func TestDeleteError(t *testing.T) {
 	c := createCustomer()
 	_, err := Delete(c.ID, "123")
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "resource_not_found_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "resource_not_found_error")
 }
 
 func TestAll(t *testing.T) {

--- a/requestor.go
+++ b/requestor.go
@@ -10,7 +10,7 @@ import (
 )
 
 // RequestAPI returns Conekta API response
-func RequestAPI(method string, url string, params ParamsConverter, customHeaders ...interface{}) ([]byte, *Error) {
+func RequestAPI(method string, url string, params ParamsConverter, customHeaders ...interface{}) ([]byte, error) {
 	requestURL := BuildURL(url)
 
 	client := &http.Client{}
@@ -65,7 +65,7 @@ func setHeaders(r *http.Request, customHeaders ...interface{}) *http.Request {
 // it takes a method, endpoint, parameters and a reference struct of conekta's models like
 // &conekta.Customer{} and fills it with the response
 // if the response has a Conekta's error it returns it and keep empty the Conekta model
-func MakeRequest(method string, endpoint string, p ParamsConverter, v interface{}, customHeaders ...interface{}) *Error {
+func MakeRequest(method string, endpoint string, p ParamsConverter, v interface{}, customHeaders ...interface{}) error {
 	res, err := RequestAPI(method, endpoint, p, customHeaders...)
 	if err != nil {
 		return err

--- a/shippingcontact/client.go
+++ b/shippingcontact/client.go
@@ -6,7 +6,7 @@ import (
 
 // Create creates a new shipping contact
 // For details see https://developers.conekta.com/api#shipping-contact.
-func Create(custID string, p *conekta.ShippingContactParams) (*conekta.ShippingContact, *conekta.Error) {
+func Create(custID string, p *conekta.ShippingContactParams) (*conekta.ShippingContact, error) {
 	sc := &conekta.ShippingContact{}
 	err := conekta.MakeRequest("POST", "/customers/"+custID+"/shipping_contacts", p, sc)
 	return sc, err
@@ -14,28 +14,28 @@ func Create(custID string, p *conekta.ShippingContactParams) (*conekta.ShippingC
 
 // Update updates a shipping contact
 // For details see https://developers.conekta.com/api#update-shipping-contact
-func Update(custID string, id string, p *conekta.ShippingContactParams) (*conekta.ShippingContact, *conekta.Error) {
+func Update(custID string, id string, p *conekta.ShippingContactParams) (*conekta.ShippingContact, error) {
 	sc := &conekta.ShippingContact{}
 	err := conekta.MakeRequest("PUT", "/customers/"+custID+"/shipping_contacts/"+id, p, sc)
 	return sc, err
 }
 
 // Find gets a shipping contact by id
-func Find(custID, id string) (*conekta.ShippingContact, *conekta.Error) {
+func Find(custID, id string) (*conekta.ShippingContact, error) {
 	sc := &conekta.ShippingContact{}
 	err := conekta.MakeRequest("GET", "/customers/"+custID+"/shipping_contacts/"+id, &conekta.EmptyParams{}, sc)
 	return sc, err
 }
 
 // Delete deletes a shipping contact
-func Delete(custID, id string) (*conekta.ShippingContact, *conekta.Error) {
+func Delete(custID, id string) (*conekta.ShippingContact, error) {
 	sc := &conekta.ShippingContact{}
 	err := conekta.MakeRequest("DELETE", "/customers/"+custID+"/shipping_contacts/"+id, &conekta.EmptyParams{}, sc)
 	return sc, err
 }
 
 // All gets all shipping contacts from a customer
-func All(custID string) (*conekta.ShippingContactList, *conekta.Error) {
+func All(custID string) (*conekta.ShippingContactList, error) {
 	scl := &conekta.ShippingContactList{}
 	err := conekta.MakeRequest("GET", "/customers/"+custID+"/shipping_contacts/", &conekta.EmptyParams{}, scl)
 	return scl, err

--- a/shippingcontact/shippingcontact_test.go
+++ b/shippingcontact/shippingcontact_test.go
@@ -19,7 +19,7 @@ func createCustomer() *conekta.Customer {
 	return cust
 }
 
-func createCustomerSC() (*conekta.ShippingContact, *conekta.Customer, *conekta.Error) {
+func createCustomerSC() (*conekta.ShippingContact, *conekta.Customer, error) {
 	cust := createCustomer()
 	scp := &conekta.ShippingContactParams{}
 	sc, err := Create(cust.ID, scp.Mock())
@@ -38,7 +38,7 @@ func TestCreateFromCustomerError(t *testing.T) {
 	cust := createCustomer()
 	_, err := Create(cust.ID, &conekta.ShippingContactParams{})
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "parameter_validation_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "parameter_validation_error")
 }
 
 func TestUpdateFromCustomer(t *testing.T) {
@@ -57,7 +57,7 @@ func TestUpdateFromCustomerError(t *testing.T) {
 	scp.Phone = "12"
 	_, err := Update(cust.ID, sc.ID, scp)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "parameter_validation_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "parameter_validation_error")
 }
 
 func TestFindFromCustomer(t *testing.T) {
@@ -71,7 +71,7 @@ func TestFindFromCustomerError(t *testing.T) {
 	c := createCustomer()
 	_, err := Find(c.ID, "123")
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "resource_not_found_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "resource_not_found_error")
 }
 
 func TestDeleteFromCustomer(t *testing.T) {
@@ -85,7 +85,7 @@ func TestDeleteFromCustomerError(t *testing.T) {
 	c := createCustomer()
 	_, err := Delete(c.ID, "123")
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "resource_not_found_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "resource_not_found_error")
 }
 
 func TestAllFromCustomer(t *testing.T) {

--- a/shippinglines/client.go
+++ b/shippinglines/client.go
@@ -6,7 +6,7 @@ import (
 
 // Create creates a new customer
 // For details see https://developers.conekta.com/api#create-customer
-func Create(orderID string, p *conekta.ShippingLinesParams) (*conekta.ShippingLines, *conekta.Error) {
+func Create(orderID string, p *conekta.ShippingLinesParams) (*conekta.ShippingLines, error) {
 	sh := &conekta.ShippingLines{}
 	err := conekta.MakeRequest("POST", "/orders/"+orderID+"/shipping_lines", p, sh)
 	return sh, err
@@ -14,14 +14,14 @@ func Create(orderID string, p *conekta.ShippingLinesParams) (*conekta.ShippingLi
 
 // Update updates a Order
 // For details see https://developers.conekta.com/api#update-Order
-func Update(orderID string, id string, p *conekta.ShippingLinesParams) (*conekta.ShippingLines, *conekta.Error) {
+func Update(orderID string, id string, p *conekta.ShippingLinesParams) (*conekta.ShippingLines, error) {
 	sh := &conekta.ShippingLines{}
 	err := conekta.MakeRequest("PUT", "/orders/"+orderID+"/shipping_lines/"+id, p, sh)
 	return sh, err
 }
 
 // Delete deletes a Order
-func Delete(orderID string, id string) (*conekta.ShippingLines, *conekta.Error) {
+func Delete(orderID string, id string) (*conekta.ShippingLines, error) {
 	sh := &conekta.ShippingLines{}
 	err := conekta.MakeRequest("DELETE", "/orders/"+orderID+"/shipping_lines/"+id, &conekta.OrderParams{}, sh)
 	return sh, err

--- a/shippinglines/shippinglines_test.go
+++ b/shippinglines/shippinglines_test.go
@@ -12,7 +12,7 @@ import (
 func init() {
 	conekta.APIKey = conekta.TestKey
 }
-func CreateOrderWithoutCharges() (*conekta.Order, *conekta.Error) {
+func CreateOrderWithoutCharges() (*conekta.Order, error) {
 	op := &conekta.OrderParams{}
 	ord, err := order.Create(op.MockWithoutCharges())
 	return ord, err
@@ -37,7 +37,7 @@ func TestCreateError(t *testing.T) {
 	_, err := Create(ord.ID, slp)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "parameter_validation_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "parameter_validation_error")
 }
 
 func TestUpdate(t *testing.T) {
@@ -57,7 +57,7 @@ func TestUpdateError(t *testing.T) {
 	_, err := Update(ord.ID, ord.ShippingLines.Data[0].ID, slp)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "parameter_validation_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "parameter_validation_error")
 
 }
 
@@ -69,5 +69,5 @@ func TestDelete(t *testing.T) {
 func TestDeleteError(t *testing.T) {
 	ord, _ := CreateOrderWithoutCharges()
 	_, err := Delete(ord.ID, "123")
-	assert.Equal(t, err.ErrorType, "resource_not_found_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "resource_not_found_error")
 }

--- a/taxlines/client.go
+++ b/taxlines/client.go
@@ -6,7 +6,7 @@ import (
 
 //Create create discount line insde a order
 // For details see https://developers.conekta.com/api#create-discount-line
-func Create(orderID string, p *conekta.TaxLinesParams) (*conekta.TaxLines, *conekta.Error) {
+func Create(orderID string, p *conekta.TaxLinesParams) (*conekta.TaxLines, error) {
 	cust := &conekta.TaxLines{}
 	err := conekta.MakeRequest("POST", "/orders/"+orderID+"/tax_lines", p, cust)
 	return cust, err
@@ -14,7 +14,7 @@ func Create(orderID string, p *conekta.TaxLinesParams) (*conekta.TaxLines, *cone
 
 //Update create discount line insde a order
 // For details see https://developers.conekta.com/api#create-discount-line
-func Update(orderID string, id string, p *conekta.TaxLinesParams) (*conekta.TaxLines, *conekta.Error) {
+func Update(orderID string, id string, p *conekta.TaxLinesParams) (*conekta.TaxLines, error) {
 	cust := &conekta.TaxLines{}
 	err := conekta.MakeRequest("PUT", "/orders/"+orderID+"/tax_lines/"+id, p, cust)
 	return cust, err
@@ -22,7 +22,7 @@ func Update(orderID string, id string, p *conekta.TaxLinesParams) (*conekta.TaxL
 
 //Delete create discount line insde a order
 // For details see https://developers.conekta.com/api#create-discount-line
-func Delete(orderID string, id string) (*conekta.TaxLines, *conekta.Error) {
+func Delete(orderID string, id string) (*conekta.TaxLines, error) {
 	tl := &conekta.TaxLines{}
 	err := conekta.MakeRequest("DELETE", "/orders/"+orderID+"/tax_lines/"+id, &conekta.OrderParams{}, tl)
 	return tl, err

--- a/taxlines/taxlines_test.go
+++ b/taxlines/taxlines_test.go
@@ -13,7 +13,7 @@ func init() {
 	conekta.APIKey = conekta.TestKey
 }
 
-func CreateOrderWithoutCharges() (*conekta.Order, *conekta.Error) {
+func CreateOrderWithoutCharges() (*conekta.Order, error) {
 	op := &conekta.OrderParams{}
 	ord, err := order.Create(op.MockWithoutCharges())
 	return ord, err
@@ -34,7 +34,7 @@ func TestCreateError(t *testing.T) {
 	_, err := Create(ord.ID, &conekta.TaxLinesParams{})
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "parameter_validation_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "parameter_validation_error")
 }
 
 func TestUpdate(t *testing.T) {
@@ -53,7 +53,7 @@ func TestUpdateError(t *testing.T) {
 	_, err := Create(ord.ID, &conekta.TaxLinesParams{})
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "parameter_validation_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "parameter_validation_error")
 }
 
 func TestDelete(t *testing.T) {
@@ -69,5 +69,5 @@ func TestDeleteError(t *testing.T) {
 	_, err := Delete(ord.ID, "123")
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "resource_not_found_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "resource_not_found_error")
 }

--- a/token/client.go
+++ b/token/client.go
@@ -8,7 +8,7 @@ import (
 
 //Create create discount line insde a order
 // For details see https://developers.conekta.com/api#create-discount-line
-func Create(p *conekta.TokenParams) (*conekta.Token, *conekta.Error) {
+func Create(p *conekta.TokenParams) (*conekta.Token, error) {
 	tk := &conekta.Token{}
 	h := map[string]string{
 		"Authorization":             "Basic " + base64.StdEncoding.EncodeToString([]byte(conekta.PubliAPIKey)),

--- a/webhook/client.go
+++ b/webhook/client.go
@@ -5,35 +5,35 @@ import (
 )
 
 // Create creates a new webhook
-func Create(p *conekta.WebhookParams) (*conekta.Webhook, *conekta.Error) {
+func Create(p *conekta.WebhookParams) (*conekta.Webhook, error) {
 	wh := &conekta.Webhook{}
 	err := conekta.MakeRequest("POST", "/webhooks", p, wh)
 	return wh, err
 }
 
 // Update updates a webhook
-func Update(id string, p *conekta.WebhookParams) (*conekta.Webhook, *conekta.Error) {
+func Update(id string, p *conekta.WebhookParams) (*conekta.Webhook, error) {
 	wh := &conekta.Webhook{}
 	err := conekta.MakeRequest("PUT", "/webhooks/"+id, p, wh)
 	return wh, err
 }
 
 // Find gets a webhook by id
-func Find(id string) (*conekta.Webhook, *conekta.Error) {
+func Find(id string) (*conekta.Webhook, error) {
 	wh := &conekta.Webhook{}
 	err := conekta.MakeRequest("GET", "/webhooks/"+id, &conekta.EmptyParams{}, wh)
 	return wh, err
 }
 
 // Delete deletes a webhook
-func Delete(id string) (*conekta.Webhook, *conekta.Error) {
+func Delete(id string) (*conekta.Webhook, error) {
 	wh := &conekta.Webhook{}
 	err := conekta.MakeRequest("DELETE", "/webhooks/"+id, &conekta.EmptyParams{}, wh)
 	return wh, err
 }
 
 // All gets all webhooks
-func All() (*conekta.WebhookList, *conekta.Error) {
+func All() (*conekta.WebhookList, error) {
 	whl := &conekta.WebhookList{}
 	err := conekta.MakeRequest("GET", "/webhooks", &conekta.EmptyParams{}, whl)
 	return whl, err

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -24,7 +24,7 @@ func TestCreate(t *testing.T) {
 func TestCreateError(t *testing.T) {
 	_, err := Create(&conekta.WebhookParams{})
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "parameter_validation_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "parameter_validation_error")
 }
 
 func TestUpdate(t *testing.T) {
@@ -50,7 +50,7 @@ func TestFind(t *testing.T) {
 func TestFindError(t *testing.T) {
 	_, err := Find("122")
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "resource_not_found_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "resource_not_found_error")
 }
 
 func TestDelete(t *testing.T) {
@@ -65,7 +65,7 @@ func TestDelete(t *testing.T) {
 func TestDeleteError(t *testing.T) {
 	_, err := Delete("122")
 	assert.NotNil(t, err)
-	assert.Equal(t, err.ErrorType, "resource_not_found_error")
+	assert.Equal(t, err.(conekta.Error).ErrorType, "resource_not_found_error")
 }
 
 func TestAll(t *testing.T) {


### PR DESCRIPTION
**Why is this change necessary?**
We need to handle errors correctly following best golang practices

**How does it address the issue?**
By refactoring functions that returns conekta.Error object

**What side effects does this change have?**
nothing

** How test it **
```go test ./...```

