### PR TITLE
Feature: Cancel Oxxo Order

### DIFF
--- a/order/client.go
+++ b/order/client.go
@@ -26,6 +26,13 @@ func Capture(id string) (*conekta.Order, error) {
 	return ord, err
 }
 
+// Cancel cancels only a oxxo Order
+func Cancel(orderID string) (*conekta.Order, error) {
+	ord := &conekta.Order{}
+	err := conekta.MakeRequest("POST", "/orders/"+orderID+"/cancel", &conekta.OrderParams{}, ord)
+	return ord, err
+}
+
 // Find gets a order by id
 func Find(id string) (*conekta.Order, error) {
 	ord := &conekta.Order{}

--- a/order/order_test.go
+++ b/order/order_test.go
@@ -181,3 +181,16 @@ func TestFind(t *testing.T) {
 	assert.Equal(t, ord.ID, res.ID)
 	assert.Nil(t, err)
 }
+
+func TestCancel(t *testing.T) {
+	op := &conekta.OrderParams{}
+	ord, _ := Create(op.OxxoMock())
+	res, err := Cancel(ord.ID)
+
+	assert.NotNil(t, res.ID)
+	assert.Equal(t, ord.ID, res.ID)
+	assert.Equal(t, "canceled", res.PaymentStatus)
+	assert.Equal(t, "canceled", res.Charges.Data[0].Status)
+	assert.Nil(t, err)
+
+}


### PR DESCRIPTION
**Why is this change neccesary?**
In order to support Google Cancelation feature
**How does it address the issue?**
Adding Cancel function to Order model and do the related test's
**What side effects does this change have?**
nothing
**How to test it?**
run

order/order_test.go