### PR TITLE
Added order void logic

### DIFF
--- a/order/client.go
+++ b/order/client.go
@@ -55,3 +55,10 @@ func Refund(orderID string, params *conekta.OrderRefundParams) (*conekta.Order, 
 	err := conekta.MakeRequest("POST", "/orders/"+orderID+"/refund", params, ord)
 	return ord, err
 }
+
+// Void voids an order
+func Void(orderID string) (*conekta.Order, error) {
+	ord := &conekta.Order{}
+	err := conekta.MakeRequest("POST", "/orders/"+orderID+"/void", &conekta.EmptyParams{}, ord)
+	return ord, err
+}

--- a/order/order_test.go
+++ b/order/order_test.go
@@ -220,3 +220,30 @@ func TestRefund(t *testing.T) {
 	assert.Equal(t, "refunded", res.PaymentStatus)
 	assert.Nil(t, err)
 }
+
+func TestVoid(t *testing.T) {
+	op := &conekta.OrderParams{
+		PreAuth: true,
+	}
+	ord, _ := Create(op.Mock())
+	res, err := Void(ord.ID)
+
+	assert.Equal(t, "voided", res.PaymentStatus)
+	assert.Nil(t, err)
+}
+
+func TestVoidError(t *testing.T) {
+	op := &conekta.OrderParams{}
+	ord, _ := Create(op.Mock())
+	_, err := Void(ord.ID)
+
+	assert.NotNil(t, err)
+	assert.Equal(t, "precondition_required_error", err.(conekta.Error).ErrorType)
+}
+
+func TestVoidNotFound(t *testing.T) {
+	_, err := Void("123")
+
+	assert.NotNil(t, err)
+	assert.Equal(t, "resource_not_found_error", err.(conekta.Error).ErrorType)
+}


### PR DESCRIPTION
**Why is this change necessary?**
We need to handle order voids

**How does it address the issue?**
By adding void function in order client

**What side effects does this change have?**
nothing