### PR TITLE
Fix amount type

### DIFF
--- a/order.go
+++ b/order.go
@@ -16,7 +16,7 @@ const (
 // OrderRefundParams returns api response object filled
 type OrderRefundParams struct {
 	Reason string `json:"reason,omitempty"`
-	Amount int    `json:"amount,omitempty"`
+	Amount int64  `json:"amount,omitempty"`
 }
 
 //OrderParams returns api response object filled


### PR DESCRIPTION
**Why is this change necessary?**
We need to fix the refund amount type in order to be the same as the others amounts

**How does it address the issue?**
By changing the int type to int64

**What side effects does this change have?**
nothing