### PR TITLE
Added logic to send a charge with payment_source_id

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -7,9 +7,10 @@ type ChargeParams struct {
 
 //PaymentMethodParams is the object to fill after api call
 type PaymentMethodParams struct {
-	Type      string `json:"type,omitempty"`
-	TokenID   string `json:"token_id,omitempty"`
-	ExpiresAt int64  `json:"expires_at,omitempty"`
+	Type            string `json:"type,omitempty"`
+	TokenID         string `json:"token_id,omitempty"`
+	PaymentSourceID string `json:"payment_source_id,omitempty"`
+	ExpiresAt       int64  `json:"expires_at,omitempty"`
 }
 
 //Charge should be a struct of the api response

--- a/customer.go
+++ b/customer.go
@@ -22,6 +22,7 @@ type Customer struct {
 // CustomerParams is the set of parameters that can be used when creating or updating a customer.
 // For details see https://developers.conekta.com/api#create-customer and https://developers.conekta.com/api#update-customer.
 type CustomerParams struct {
+	ID               string                       `json:"customer_id,omitempty"`
 	Name             string                       `json:"name,omitempty"`
 	Phone            string                       `json:"phone,omitempty"`
 	Email            string                       `json:"email,omitempty"`

--- a/order.go
+++ b/order.go
@@ -45,13 +45,19 @@ type Order struct {
 	UpdatedAt       int64              `json:"updated_at,omitempty"`
 	PreAuth         bool               `json:"pre_authorize,omitempty"`
 	Metadata        struct{}           `json:"metadata,omitempty"`
-	CustomerInfo    *Customer          `json:"customer_info,omitempty"`
+	CustomerInfo    *CustomerInfo      `json:"customer_info,omitempty"`
 	ShippingContact *ShippingContact   `json:"shipping_contact,omitempty"`
 	LineItems       *LineItemsList     `json:"line_items,omitempty"`
 	TaxLines        *TaxLinesList      `json:"tax_lines,omitempty"`
 	ShippingLines   *ShippingLinesList `json:"shipping_lines,omitempty"`
 	DiscountLines   *DiscountLinesList `json:"discount_lines,omitempty"`
 	Charges         *ChargesList       `json:"charges,omitempty"`
+}
+
+// CustomerInfo describes customer info
+type CustomerInfo struct {
+	CustomerID string `json:"customer_id,omitempty"`
+	*Customer
 }
 
 // OrderList is a list of shippingLines


### PR DESCRIPTION
**Why is this change necessary?**
To allow orders with payment_source_id

**How does it address the issue?**
By adding a payment_source_id field in the charge requests 

**What side effects does this change have?**
nothing