### PR TITLE
Feature: INT-DEVELOPMENT-get-auth-from-paynotification-wh

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -51,6 +51,7 @@ type PaymentMethod struct {
 	ExpiresAt     int64           `json:"expires_at,omitempty"`
 	Description   string          `json:"description,omitempty"`
 	Address       *DefaultAddress `json:"address,omitempty"`
+	ResponseHash  *ResponseHash   `json:"response_hash,omitempty"`
 }
 
 //DefaultAddress should be nested struct of PaymentMethod
@@ -62,6 +63,17 @@ type DefaultAddress struct {
 	Country    string `json:"country,omitempty"`
 	Object     string `json:"object,omitempty"`
 	PostalCode string `json:"postal_code,omitempty"`
+}
+
+// ResponseHash should be nested struct of PaymentMethod
+type ResponseHash struct {
+	Capture []*Capture `json:"capture,omitempty"`
+}
+
+// Capture should be nested struct of ResponseHash
+type Capture struct {
+	// TODO: Add all 'capture' fields
+	Auth string `json:"auth,omitempty"`
 }
 
 //ChargesList is a list of shippingLines


### PR DESCRIPTION
**1. Why is this change necessary?**
- `payment_method` did not include the auth code

**2. How does it address the issue?**
- `payment_method` now includes the auth code

**3. What side effects does this change have?**
- None