### PR TITLE
 Fix: Auth code and store code 

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -50,6 +50,8 @@ type PaymentMethod struct {
 	ServiceNumber string          `json:"service_number,omitempty"`
 	ExpiresAt     int64           `json:"expires_at,omitempty"`
 	Description   string          `json:"description,omitempty"`
+	AuthCode      int64           `json:"auth_code,omitempty"`
+	Store         string          `json:"store,omitempty"`
 	Address       *DefaultAddress `json:"address,omitempty"`
 }
 


### PR DESCRIPTION
1. Why is this change necessary?
- `auth_code` is in `ResponseHash` struct
- `store` code is not in `payment_method` struct

2. How does it address the issue?
- `auth_code` was moved to `payment_method` struct
- `store` was added to `payment_method` struct

3. What side effects does this change have?
- `ResponseHash` is no longer used
- Reverted commits