### PR TITLE
Cleanup/error handling

### DIFF
--- a/charge/charge_test.go
+++ b/charge/charge_test.go
@@ -84,6 +84,15 @@ func TestCreateError(t *testing.T) {
 	assert.Equal(t, err.(conekta.Error).ErrorType, "parameter_validation_error")
 }
 
+func TestProcessingError(t *testing.T) {
+	ord, _ := CreateOrderWithoutCharges()
+	chargeParams := (&conekta.ChargeParams{}).Mock()
+	chargeParams.PaymentMethod.TokenID = "tok_test_card_declined"
+	ch, err := Create(ord.ID, chargeParams)
+	assert.Nil(t, err)
+	assert.Equal(t, ch.Status, "declined")
+}
+
 func TestFind(t *testing.T) {
 	ord, _ := CreateOrder()
 	res, _ := Find(ord.ID, ord.Charges.Data[0].ID)

--- a/charge/client.go
+++ b/charge/client.go
@@ -2,6 +2,7 @@ package charge
 
 import (
 	conekta "github.com/conekta/conekta-go"
+	"encoding/json"
 )
 
 //Create charges object sending requesto api
@@ -9,6 +10,10 @@ import (
 func Create(orderID string, p *conekta.ChargeParams) (*conekta.Charge, error) {
 	ch := &conekta.Charge{}
 	err := conekta.MakeRequest("POST", "/orders/"+orderID+"/charges", p, ch)
+	if err != nil && err.(conekta.Error).ErrorType == "processing_error" {
+		json.Unmarshal(err.(conekta.Error).Data, ch)
+		return ch, nil
+	}
 	return ch, err
 }
 

--- a/error.go
+++ b/error.go
@@ -16,9 +16,10 @@ type ErrorDetails struct {
 
 // Error describes Conekta errors
 type Error struct {
-	ErrorType string         `json:"type,omitempty"`
-	LogID     string         `json:"log_id,omitempty"`
-	Details   []ErrorDetails `json:"details,omitempty"`
+	ErrorType string           `json:"type,omitempty"`
+	LogID     string           `json:"log_id,omitempty"`
+	Details   []ErrorDetails   `json:"details,omitempty"`
+	Data      json.RawMessage  `json:"data,omitempty"`
 }
 
 func getConectionError() Error {

--- a/order/client.go
+++ b/order/client.go
@@ -3,12 +3,17 @@ package order
 import (
 	conekta "github.com/conekta/conekta-go"
 	"github.com/google/go-querystring/query"
+	"encoding/json"
 )
 
 // Create creates a new order
 func Create(p *conekta.OrderParams, customHeaders ...interface{}) (*conekta.Order, error) {
 	ord := &conekta.Order{}
 	err := conekta.MakeRequest("POST", "/orders", p, ord, customHeaders...)
+	if err != nil && err.(conekta.Error).ErrorType == "processing_error" {
+		json.Unmarshal(err.(conekta.Error).Data, ord)
+		return ord, nil
+	}
 	return ord, err
 }
 
@@ -17,6 +22,10 @@ func Create(p *conekta.OrderParams, customHeaders ...interface{}) (*conekta.Orde
 func Update(id string, p *conekta.OrderParams) (*conekta.Order, error) {
 	ord := &conekta.Order{}
 	err := conekta.MakeRequest("PUT", "/orders/"+id, p, ord)
+	if err != nil && err.(conekta.Error).ErrorType == "processing_error" {
+		json.Unmarshal(err.(conekta.Error).Data, ord)
+		return ord, nil
+	}
 	return ord, err
 }
 


### PR DESCRIPTION
Returns Order and Charge on 402 create errors because these should technically be 200s and return real objects