### PR TITLE
Cleanup/remove total

### DIFF
--- a/conekta.go
+++ b/conekta.go
@@ -27,7 +27,6 @@ var Locale string
 type ListMeta struct {
 	Object      string `json:"object,omitempty"`
 	HasMore     bool   `json:"has_more,omitempty"`
-	Total       int    `json:"total,omitempty"`
 	NextPageURL string `json:"next_page_url,omitempty"`
 }
 

--- a/customer/customer_test.go
+++ b/customer/customer_test.go
@@ -18,8 +18,7 @@ func TestCreate(t *testing.T) {
 	assert.Equal(t, cp.Name, cust.Name)
 	assert.Equal(t, cp.Phone, cust.Phone)
 	assert.Equal(t, cp.Corporate, cust.Corporate)
-	assert.Equal(t, len(cp.ShippingContacts), cust.ShippingContacts.Total)
-	assert.Equal(t, len(cp.PaymentSources), cust.PaymentSources.Total)
+	assert.NotZero(t, len(cust.ShippingContacts.Data))
 	assert.Nil(t, err)
 }
 
@@ -37,8 +36,8 @@ func TestCreateWithCardAsPaymentSource(t *testing.T) {
 	assert.Equal(t, cp.Name, cust.Name)
 	assert.Equal(t, cp.Phone, cust.Phone)
 	assert.Equal(t, cp.Corporate, cust.Corporate)
-	assert.Equal(t, len(cp.ShippingContacts), cust.ShippingContacts.Total)
-	assert.Equal(t, len(cp.PaymentSources), cust.PaymentSources.Total)
+	assert.NotZero(t, len(cust.ShippingContacts.Data))
+	assert.NotZero(t, len(cust.PaymentSources.Data))
 	assert.NotNil(t, cust.DefaultPaymentSourceID)
 	assert.Nil(t, err)
 }
@@ -102,6 +101,6 @@ func TestAll(t *testing.T) {
 	cp := &conekta.CustomerParams{}
 	Create(cp.Mock())
 	cl, err := All()
-	assert.NotZero(t, cl.Total)
+	assert.NotZero(t, len(cl.Data))
 	assert.Nil(t, err)
 }

--- a/order/order_test.go
+++ b/order/order_test.go
@@ -18,18 +18,15 @@ func TestCreate(t *testing.T) {
 	op := &conekta.OrderParams{}
 	ord, err := Create(op.Mock())
 
-	assert.Equal(t, len(op.DiscountLines), ord.DiscountLines.Total)
 	assert.Equal(t, op.DiscountLines[0].Amount, ord.DiscountLines.Data[0].Amount)
 	assert.Equal(t, op.DiscountLines[0].Code, ord.DiscountLines.Data[0].Code)
 	assert.Equal(t, op.DiscountLines[0].Type, ord.DiscountLines.Data[0].Type)
 	assert.NotEqual(t, nil, ord.DiscountLines.Data[0].ID)
 
-	assert.Equal(t, len(op.TaxLines), ord.TaxLines.Total)
 	assert.Equal(t, int64(op.TaxLines[0].Amount), ord.TaxLines.Data[0].Amount)
 	assert.Equal(t, op.TaxLines[0].Description, ord.TaxLines.Data[0].Description)
 	assert.NotEqual(t, nil, ord.TaxLines.Data[0].ID)
 
-	assert.Equal(t, len(op.LineItems), ord.LineItems.Total)
 	assert.Equal(t, op.LineItems[0].Name, ord.LineItems.Data[0].Name)
 	assert.Equal(t, op.LineItems[0].Quantity, ord.LineItems.Data[0].Quantity)
 	assert.Equal(t, op.LineItems[0].UnitPrice, ord.LineItems.Data[0].UnitPrice)
@@ -89,19 +86,16 @@ func TestOxxoCreate(t *testing.T) {
 	ord, err := Create(op.OxxoMock())
 
 	//root order
-	assert.Equal(t, len(op.DiscountLines), ord.DiscountLines.Total)
 	assert.Equal(t, op.DiscountLines[0].Amount, ord.DiscountLines.Data[0].Amount)
 	assert.Equal(t, op.DiscountLines[0].Code, ord.DiscountLines.Data[0].Code)
 	assert.Equal(t, op.DiscountLines[0].Type, ord.DiscountLines.Data[0].Type)
 	assert.NotEqual(t, nil, ord.DiscountLines.Data[0].ID)
 	//tax lines
-	assert.Equal(t, len(op.TaxLines), ord.TaxLines.Total)
 	assert.Equal(t, int64(op.TaxLines[0].Amount), ord.TaxLines.Data[0].Amount)
 	assert.Equal(t, op.TaxLines[0].Description, ord.TaxLines.Data[0].Description)
 	assert.NotEqual(t, nil, ord.TaxLines.Data[0].ID)
 
 	//line items
-	assert.Equal(t, len(op.LineItems), ord.LineItems.Total)
 	assert.Equal(t, op.LineItems[0].Name, ord.LineItems.Data[0].Name)
 	assert.Equal(t, op.LineItems[0].Quantity, ord.LineItems.Data[0].Quantity)
 	assert.Equal(t, op.LineItems[0].UnitPrice, ord.LineItems.Data[0].UnitPrice)
@@ -182,7 +176,7 @@ func TestWhere(t *testing.T) {
 
 	res, _ := Where(op)
 
-	assert.NotNil(t, res.Total)
+	assert.NotZero(t, len(res.Data))
 	assert.True(t, res.HasMore)
 	assert.Equal(t, "list", res.Object)
 

--- a/payee/payee_test.go
+++ b/payee/payee_test.go
@@ -59,6 +59,6 @@ func TestDeleteError(t *testing.T) {
 func TestAll(t *testing.T) {
 	createPayee()
 	pl, err := All()
-	assert.NotZero(t, pl.Total)
+	assert.NotZero(t, len(pl.Data))
 	assert.Nil(t, err)
 }

--- a/paymentsource/paymentsource_test.go
+++ b/paymentsource/paymentsource_test.go
@@ -106,6 +106,6 @@ func TestDeleteError(t *testing.T) {
 func TestAll(t *testing.T) {
 	_, c, _ := createPaymentSource()
 	psl, err := All(c.ID)
-	assert.NotZero(t, psl.Total)
+	assert.NotZero(t, len(psl.Data))
 	assert.Nil(t, err)
 }

--- a/shippingcontact/shippingcontact_test.go
+++ b/shippingcontact/shippingcontact_test.go
@@ -91,6 +91,6 @@ func TestDeleteFromCustomerError(t *testing.T) {
 func TestAllFromCustomer(t *testing.T) {
 	_, c, _ := createCustomerSC()
 	scl, err := All(c.ID)
-	assert.NotZero(t, scl.Total)
+	assert.NotZero(t, len(scl.Data))
 	assert.Nil(t, err)
 }

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -72,7 +72,7 @@ func TestAll(t *testing.T) {
 	whp := &conekta.WebhookParams{}
 	wh, _ := Create(whp.Mock())
 	whl, err := All()
-	assert.NotZero(t, whl.Total)
+	assert.NotZero(t, len(whl.Data))
 	assert.Nil(t, err)
 	Delete(wh.ID)
 }


### PR DESCRIPTION
Removes the deprecated Total field for lists as we will be using the more scalable `has_more` feature instead