### PR TITLE
Error handling tests for Golang

### DIFF
--- a/subscription/Subscription_test.go
+++ b/subscription/Subscription_test.go
@@ -18,9 +18,19 @@ func CreateCustomerTest() (*conekta.Customer, error){
 	return c, err
 }
 
+func CreateDeclinedCustomerTest() (*conekta.Customer, error){
+	cus := &conekta.CustomerParams{}
+	customerParams := cus.MockCustomerPaymentSource()
+	customerParams.PaymentSources[0].TokenID = "tok_test_card_declined"
+	c, err := customer.Create(customerParams)
+	return c, err
+}
+
 func CreatePlanTest() (*conekta.Plan, error) {
 	pl := &conekta.PlanParams{}
-	p, err := plan.Create(pl.MockPlanCreate())
+        pl.MockPlanCreate()
+	pl.TrialPeriodDays = 0
+	p, err := plan.Create(pl)
 	return p, err
 }
 
@@ -36,6 +46,23 @@ func TestCreate(t *testing.T){
 
 	assert.Equal(t, sp.CardID, sub.CardID)
 	assert.Equal(t, sp.PlanID, sub.PlanID)
+
+	assert.Nil(t, err)
+}
+
+func TestCreateProcessingError(t *testing.T){
+	c, _ := CreateDeclinedCustomerTest()
+	p, _ := CreatePlanTest()
+
+	sp := &conekta.SubscriptionParams{
+		PlanID: p.ID,
+		CardID: c.DefaultPaymentSourceID,
+	}
+	sub, err := Create(c.ID, sp)
+
+	assert.Equal(t, sp.CardID, sub.CardID)
+	assert.Equal(t, sp.PlanID, sub.PlanID)
+	assert.Equal(t, "past_due", sub.Status)
 
 	assert.Nil(t, err)
 }
@@ -62,6 +89,22 @@ func TestResume(t *testing.T) {
 
 	_, err := Resume(sub.CustomerID)
 	assert.Nil(t, err)
+}
+
+func TestResumeProcessingError(t *testing.T) {
+	c, _ := CreateDeclinedCustomerTest()
+	p, _ := CreatePlanTest()
+
+	sp := &conekta.SubscriptionParams{
+		PlanID: p.ID,
+		CardID: c.DefaultPaymentSourceID,
+	}
+	sub, _ := Create(c.ID, sp)
+	Pause(sub.CustomerID)
+
+	pausedSub, err := Resume(sub.CustomerID)
+	assert.Nil(t, err)
+	assert.Equal(t, "past_due", pausedSub.Status)
 }
 
 func TestPause(t *testing.T) {

--- a/subscription/client.go
+++ b/subscription/client.go
@@ -2,6 +2,7 @@ package subscription
 
 import (
 	conekta "github.com/conekta/conekta-go"
+	"encoding/json"
 	//"github.com/google/go-querystring/query"
 )
 
@@ -9,6 +10,10 @@ import (
 func Create(id string, p *conekta.SubscriptionParams, customHeaders ...interface{}) (*conekta.Subscription, error) {
 	sub := &conekta.Subscription{}
 	err := conekta.MakeRequest("POST", "/customers/"+id+"/subscription", p, sub, customHeaders...)
+	if err != nil && err.(conekta.Error).ErrorType == "processing_error" {
+		json.Unmarshal(err.(conekta.Error).Data, sub)
+		return sub, nil
+	}
 	return sub, err
 }
 
@@ -16,12 +21,20 @@ func Create(id string, p *conekta.SubscriptionParams, customHeaders ...interface
 func Update(id string, p *conekta.SubscriptionParams) (*conekta.Subscription, error) {
 	sub := &conekta.Subscription{}
 	err := conekta.MakeRequest("POST", "/customers/"+id+"/subscription", p, sub)
+	if err != nil && err.(conekta.Error).ErrorType == "processing_error" {
+		json.Unmarshal(err.(conekta.Error).Data, sub)
+		return sub, nil
+	}
 	return sub, err
 }
 
 func Resume(id string) (*conekta.Subscription, error) {
 	sub := &conekta.Subscription{}
 	err := conekta.MakeRequest("POST", "/customers/"+id+"/subscription/resume", &conekta.SubscriptionParams{}, sub)
+	if err != nil && err.(conekta.Error).ErrorType == "processing_error" {
+		json.Unmarshal(err.(conekta.Error).Data, sub)
+		return sub, nil
+	}
 	return sub, err
 }
 


### PR DESCRIPTION
Responds to 422 processing errors by returning the updated object rather than throwing an exception.