### PR TITLE
Remove 'omitempty' json tag from Amount in ShippingLinesParams

### DIFF
--- a/shippinglines.go
+++ b/shippinglines.go
@@ -2,7 +2,7 @@ package conekta
 
 //ShippingLinesParams is the set of parameters that can be used when creating or updating a shipping contact.
 type ShippingLinesParams struct {
-	Amount         int64  `json:"amount,omitempty"`
+	Amount         int64  `json:"amount"`
 	TrackingNumber string `json:"tracking_number,omitempty"`
 	Carrier        string `json:"carrier,omitempty"`
 	Method         string `json:"method,omitempty"`


### PR DESCRIPTION
The 'omitempty' tag omits zero-valued integer fields from marshaled
json. By removing the tag we allow the inclusion of a zero cost Shipping
Line, useful for selling items with no shipping cost when a given
account enforces the inclusion of Shipping Lines.