### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,6 +4,8 @@ on:
     branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
+permissions:
+  contents: read
 jobs:
   tests:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/conekta/conekta-go/security/code-scanning/2](https://github.com/conekta/conekta-go/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root in `.github/workflows/go.yml`, directly under `on:` (or after it) and before `jobs:`.  
For this workflow, the best minimal fix is:

- `contents: read`

This preserves current behavior for checkout and test execution while enforcing least privilege for all jobs in the workflow. No imports, methods, or external definitions are needed—just YAML configuration in the shown file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
